### PR TITLE
Start HTTP Server in Example executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 🏗👨‍🎓 Weasel is an HTTP Server implementation written in [Swift](https://github.com/apple/swift). It's sole purpose is for me to learn about HTTP and lower-level code.
 
+## Demo
+
+[`Weasel`](https://github.com/slashmo/weasel/tree/master/Sources/Weasel) itself is a Swift library package that you, in theory, could **but definetely shouldn't** use in your own backend applications. Included in this repository is also an executable [`Example`](https://github.com/slashmo/weasel/tree/master/Sources/Example) which spins up an HTTP Server using the `Weasel` library.
+
+```sh
+swift package resolve
+swift run
+```
+
 ### Projects inspiring this implementation
 
 - [Swift NIO](https://github.com/apple/swift-nio)

--- a/Sources/Example/main.swift
+++ b/Sources/Example/main.swift
@@ -1,1 +1,5 @@
-print("Hello, Weasel!")
+import Weasel
+
+let address = try SocketAddress(resolvingHost: "localhost", port: 8080)
+let server = try HTTPServer(tcpListener: .bound(to: address))
+try server.start()


### PR DESCRIPTION
The `Example` executable now starts a `Weasel`-powered HTTP server.